### PR TITLE
fix: deleteText currPos left and right both null

### DIFF
--- a/src/types/YText.js
+++ b/src/types/YText.js
@@ -498,8 +498,8 @@ const deleteText = (transaction, currPos, length) => {
   if (start) {
     cleanupFormattingGap(transaction, start, currPos.right, startAttrs, currPos.currentAttributes)
   }
-  const parent = /** @type {AbstractType<any>} */ (/** @type {Item} */ (currPos.left || currPos.right).parent)
-  if (parent._searchMarker) {
+  const parent = /** @type {AbstractType<any>} */ (/** @type {Item} */ (currPos.left || currPos.right)?.parent)
+  if (parent?._searchMarker) {
     updateMarkerChanges(parent._searchMarker, currPos.index, -startLength + length)
   }
   return currPos


### PR DESCRIPTION
Handle the case where both `currPos.left` and `currPos.right` are null in `YText::deleteText` to prevent error `Cannot read properties of null (reading 'parent')` .

Fixes https://github.com/yjs/yjs/issues/504.